### PR TITLE
Custom list of processors option

### DIFF
--- a/scripts/anonymize-log
+++ b/scripts/anonymize-log
@@ -126,7 +126,7 @@ class Ipv4Processor(LineProcessorBase):
     for match in self.pattern.finditer(line):
       matched_string = match.group(0)
       left_octets, _ = matched_string.rsplit('.', 1)
-      replace_string = '%s.x' % left_octets
+      replace_string = '%s.0' % left_octets
       line = line.replace(matched_string, replace_string, 1)
 
     return line
@@ -157,7 +157,7 @@ class Ipv6Processor(LineProcessorBase):
 
       for segment_i, segment in enumerate(reversed(segments)):
         if segment != '':
-          segments[-1 - segment_i] = 'x'
+          segments[-1 - segment_i] = '0'
           break
 
       replace_string = ':'.join(segments)
@@ -291,11 +291,14 @@ def caught_main(cleaner):
   parser.add_argument('in_file', nargs='?', default='-',
                       help='file to read from, stdin: -')
   parser.add_argument('out_file', nargs='?', default='-',
-                      help='file to write to, stdout: -')
+                      help='file to write to, stdout: -'),
+  parser.add_argument('-m', '--modules', default=str.join(',',[l.__name__ for l in LineProcessorRegistry.items]),
+                      help='comma separated list of modules to process' )
+
+
   # initialize processors
   processors = set(Processor(parser)
                    for Processor in LineProcessorRegistry.items)
-
   args = parser.parse_args()
 
   # set up logger
@@ -310,6 +313,17 @@ def caught_main(cleaner):
   for processor in processors:
     debug('setting up %s', processor)
     processor.setup(args)
+
+  # process only modules selected
+  debug('create custom processor list')
+  if args.modules:
+    newp = processors.copy()
+    em = vars(args)['modules'].split(',')
+    debug('enabled modules: %s' % str.join(',',em))
+    for p in newp:
+      if type(p).__name__ not in em:
+        debug('remove processor: %s' % type(p).__name__)
+        processors.remove(p)
 
   in_file = get_in_file(args, cleaner)
   out_file = get_out_file(args, cleaner)


### PR DESCRIPTION
Maybe useful. Works with new processors also if current registry is not changed.

anonymize-log -d -m Ipv4Processor,Ipv6Processor
DEBUG::setting up processors
DEBUG::setting up <__main__.Ipv4Processor object at 0x7f9b72f26208>
DEBUG::setting up <__main__.EmailProcessor object at 0x7f9b72f18e10>
DEBUG::setting up <__main__.Ipv6Processor object at 0x7f9b72f262b0>
DEBUG::create custom processor list
DEBUG::enabled modules: Ipv4Processor,Ipv6Processor
DEBUG::remove processor: EmailProcessor
DEBUG::open input file "-"
DEBUG::open output file "-"
DEBUG::doing argument sanity checks
INFO::processing lines